### PR TITLE
Dockerfile: bump Alpine from 3.13 to 3.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.13 as builder
+FROM alpine:3.17 as builder
 
 ARG VERSION=0.8.1
 ARG RELEASE=zig-linux-x86_64-${VERSION}
@@ -10,7 +10,7 @@ ADD https://ziglang.org/download/${VERSION}/${RELEASE}.tar.xz .
 RUN tar -xvf ${RELEASE}.tar.xz
 RUN mv /tmp/${RELEASE} /opt/zig
 
-FROM alpine:3.13 as runner
+FROM alpine:3.17 as runner
 
 # install packages required to run the tests
 RUN apk add --no-cache bash jq


### PR DESCRIPTION
See the [list of releases][1].

[1]: https://alpinelinux.org/releases/

---

To-do:

- [ ] Re-run CI after merging https://github.com/exercism/zig-test-runner/pull/20