### PR TITLE
Dockerfile: bump Zig from 0.10.1 to 0.11.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.17 as builder
 
-ARG VERSION=0.10.1
+ARG VERSION=0.11.0
 ARG RELEASE=zig-linux-x86_64-${VERSION}
 
 RUN apk add --no-cache curl


### PR DESCRIPTION
Zig 0.11.0 isn't quite released yet, so CI will fail. Apparently the tarballs will finish building in about 5 hours.

Before merging this we must:

- [ ] Successfully merge the corresponding PR in the track repo

---

See the [release notes][1].

Closes: #36

[1]: https://ziglang.org/download/0.11.0/release-notes.html

