### PR TITLE
Dockerfile: bump Alpine from 3.17 to 3.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17 as builder
+FROM alpine:3.18 as builder
 
 ARG VERSION=0.10.1
 ARG RELEASE=zig-linux-x86_64-${VERSION}
@@ -10,7 +10,7 @@ ADD https://ziglang.org/download/${VERSION}/${RELEASE}.tar.xz .
 RUN tar -xvf ${RELEASE}.tar.xz
 RUN mv /tmp/${RELEASE} /opt/zig
 
-FROM alpine:3.17 as runner
+FROM alpine:3.18 as runner
 
 # install packages required to run the tests
 RUN apk add --no-cache bash jq


### PR DESCRIPTION
See the release notes for [3.18.0][1] and [3.18.2][2] (it looks like there was no proper 3.18.1 release).

[1]: https://alpinelinux.org/posts/Alpine-3.18.0-released.html
[2]: https://alpinelinux.org/posts/Alpine-3.15.9-3.16.6-3.17.4-3.18.2-released.html

Closes: #37

---

Refs: https://github.com/exercism/zig-test-runner/issues/38 (in a later PR, we should probably write 3.18.2)
CI probably fails until we resolve https://github.com/exercism/zig-test-runner/issues/26

Previous update: 8512478064b0c43fc15192a260586e51c5a3104f