### PR TITLE
Make tests of the runner itself deterministic

### DIFF
--- a/bin/run-tests.sh
+++ b/bin/run-tests.sh
@@ -22,21 +22,20 @@ for test_dir in tests/*; do
 
     bin/run.sh "${test_dir_name}" "${test_dir_path}" "${test_dir_path}"
 
-    # OPTIONAL: Normalize the results file
-    # If the results.json file contains information that changes between 
-    # different test runs (e.g. timing information or paths), you should normalize
-    # the results file to allow the diff comparison below to work as expected
-    # sed -i -E \
-    #   -e 's/Elapsed time: [0-9]+\.[0-9]+ seconds//g' \
-    #   -e "s~${test_dir_path}~/solution~g" \
-    #   "${results_file_path}"
+    for file in "$results_file_path" "$expected_results_file_path"; do
+        # We remove nondeterministic memory locations of instructions.
+        # See: https://github.com/exercism/zig-test-runner/issues/26
+        sed -E 's/0x[a-f0-9]{6}/<MEMHASH>/g' "${file}" > "${file}.tmp"
+    done
 
     echo "${test_dir_name}: comparing results.json to expected_results.json"
-    diff "${results_file_path}" "${expected_results_file_path}"
+    diff "${results_file_path}.tmp" "${expected_results_file_path}.tmp"
 
     if [ $? -ne 0 ]; then
         exit_code=1
     fi
+
+    rm -f "${results_file_path}.tmp" "${expected_results_file_path}.tmp"
 done
 
 exit ${exit_code}


### PR DESCRIPTION
This is a change to `bin/run-tests.sh` which only affects the tests of the test runner itself. These do not affect `bin/run.sh` or `bin/run-in-docker.sh`

Closes #26
