### PR TITLE
Dockerfile: consolidate consecutive RUN instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ RUN apk add --no-cache curl
 
 WORKDIR /tmp
 ADD https://ziglang.org/download/${VERSION}/${RELEASE}.tar.xz .
-RUN tar -xvf ${RELEASE}.tar.xz
-RUN mv /tmp/${RELEASE} /opt/zig
+RUN tar -xvf ${RELEASE}.tar.xz \
+    && mv /tmp/${RELEASE} /opt/zig
 
 FROM alpine:3.18 as runner
 


### PR DESCRIPTION
Avoid creating an extra layer.

For more background, see [Docker development best practices][1] and hadolint rule [DL3059][2].

[1]: https://docs.docker.com/develop/dev-best-practices/
[2]: https://github.com/hadolint/hadolint/wiki/DL3059