### PR TITLE
Dockerfile: pin Alpine version as 3.18.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM alpine:3.18 as builder
+ARG REPO=alpine
+ARG IMAGE=3.18.2@sha256:25fad2a32ad1f6f510e528448ae1ec69a28ef81916a004d3629874104f8a7f70
+FROM ${REPO}:${IMAGE} AS builder
 
 ARG VERSION=0.11.0
 ARG RELEASE=zig-linux-x86_64-${VERSION}
@@ -10,7 +12,7 @@ ADD https://ziglang.org/download/${VERSION}/${RELEASE}.tar.xz .
 RUN tar -xvf ${RELEASE}.tar.xz
 RUN mv /tmp/${RELEASE} /opt/zig
 
-FROM alpine:3.18 as runner
+FROM ${REPO}:${IMAGE} AS runner
 
 # install packages required to run the tests
 RUN apk add --no-cache bash jq


### PR DESCRIPTION
Make the image more reproducible, at the cost of more bumping.

Closes: #38

---

Previous update: 1db5896d76ea8da08dee3d62c18a7c03352b7fb9