### PR TITLE
.github, Dockerfile: add hadolint workflow

### DIFF
--- a/.github/workflows/lint_dockerfile.yml
+++ b/.github/workflows/lint_dockerfile.yml
@@ -1,0 +1,15 @@
+name: Lint Dockerfile
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  hadolint:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
+
+      - name: Run hadolint
+        uses: hadolint/hadolint-action@54c9adbab1582c2ef04b2016b760714a4bfde3cf
+        with:
+          dockerfile: Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ FROM ${REPO}:${IMAGE} AS builder
 ARG VERSION=0.11.0
 ARG RELEASE=zig-linux-x86_64-${VERSION}
 
+# We can't reliably pin the package versions on Alpine, so we ignore the linter warning.
+# See https://gitlab.alpinelinux.org/alpine/abuild/-/issues/9996
+# hadolint ignore=DL3018
 RUN apk add --no-cache curl
 
 WORKDIR /tmp
@@ -15,6 +18,7 @@ RUN tar -xvf ${RELEASE}.tar.xz \
 FROM ${REPO}:${IMAGE} AS runner
 
 # install packages required to run the tests
+# hadolint ignore=DL3018
 RUN apk add --no-cache bash jq
 
 COPY --from=builder /opt/zig/ /opt/zig/


### PR DESCRIPTION
Make CI lint our Dockerfile with [hadolint][1], and add a couple of ignores so that hadolint won't complain.

Closes: #45

[1]: https://github.com/hadolint/hadolint

