### PR TITLE
.dockerignore: ignore unnecessary repo files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,12 @@
 .git/
 .appends/
 .github/
+.dockerignore
 .gitattributes
 .gitignore
+CODE_OF_CONDUCT.md
+LICENSE
+README.md
 Dockerfile
 bin/run-in-docker.sh
 bin/run-tests-in-docker.sh


### PR DESCRIPTION
On the penultimate line of our Dockerfile we have the instruction:

https://github.com/exercism/zig-test-runner/blob/f7cfedefe0db5734e5bce0962bb2c5baa0a3c84e/Dockerfile#L28

which previously copied some small unneeded repo files into the images. Add them to the ignore list so that they are no longer copied.

With this commit, the `/opt/test-runner directory` in the image contains only `/opt/test-runner/bin/run.sh`.

We could instead change that `COPY` instruction to copy that specific file, but let's stick with the `.dockerignore` approach for now.

Refs: #34 (to a tiny extent)