### PR TITLE
Dockerfile: remove unneeded libc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ WORKDIR /tmp
 ADD https://ziglang.org/download/${VERSION}/${RELEASE}.tar.xz .
 RUN tar -xvf ${RELEASE}.tar.xz \
     && rm -rf /tmp/${RELEASE}/doc \
+    && rm -rf /tmp/${RELEASE}/lib/libc/include/any-windows-any \
     && mv /tmp/${RELEASE} /opt/zig
 
 # Initialize a zig cache


### PR DESCRIPTION
Exercism has been trying to [decrease the size of deployed Docker images][1].

The Zig test runner image was larger than necessary because Zig [ships with many libcs][2]. However, Exercism doesn't need to cross compile. We just need Zig to compile natively on x86_64, in the default debug mode, on Alpine Linux (with Alpine's musl libc).

As a simple step, remove the largest bundled libc. This reduces the image size by 62 MB (from 332 MB to 270 MB). We can consider removing more of them later.

The complete list of the biggest contributors to the remaining size:

```text
149 MB  /opt/zig/zig
 40 MB  /root/.cache/zig/
 36 MB  /opt/zig/lib/libc/
 12 MB  /opt/zig/lib/include/
 11 MB  /opt/zig/lib/std/
  8 MB  /opt/zig/lib/libcxx/
  4 MB  /lib/libcrypto.so.3
  3 MB  /opt/zig/lib/tsan/
  1 MB  /usr/lib/
  1 MB  /bin/
```

So the Zig compiler executable is 55% of the remaining size. It would be possible to use a smaller Zig executable, but the easiest way would be to wait for upstream to ship one: in the future, Zig [plans to ship an executable that's about 5 MB][3].

Even better would be if Exercism could eventually use the same approach as auguste's zig + zls [playground][4] (and see [repo][5]).

Refs: #34

[1]: https://forum.exercism.org/t/docker-image-sizes/6478
[2]: https://andrewkelley.me/post/zig-cc-powerful-drop-in-replacement-gcc-clang.html
[3]: https://www.github.com/ziglang/zig/issues/16270
[4]: https://playground.zigtools.org/
[5]: https://github.com/zigtools/playground