### PR TITLE
bin(run), Dockerfile: use `sh` not `bash`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ FROM ${REPO}:${IMAGE} AS runner
 
 # install packages required to run the tests
 # hadolint ignore=DL3018
-RUN apk add --no-cache bash jq
+RUN apk add --no-cache jq
 
 COPY --from=builder /opt/zig/ /opt/zig/
 COPY --from=builder /root/.cache/zig/ /root/.cache/zig/

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 # Synopsis:
 # Run the test runner on a solution.
@@ -22,7 +22,7 @@ if [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ]; then
 fi
 
 slug="$1"
-test_file="test_${slug//-/_}.zig"
+test_file="$(echo "test_${slug}.zig" | tr '-' '_')"
 solution_dir=$(realpath "${2%/}")
 output_dir=$(realpath "${3%/}")
 results_file="${output_dir}/results.json"
@@ -32,14 +32,15 @@ mkdir -p "${output_dir}"
 
 echo "${slug}: testing..."
 
-pushd "${solution_dir}" > /dev/null || exit 1
+start_dir="$(pwd)"
+cd "${solution_dir}" || exit 1
 
 # Run the tests for the provided implementation file and redirect stdout and
 # stderr to capture it
 test_output=$(zig test "${test_file}" 2>&1)
 exit_code=$?
 
-popd > /dev/null || exit 1
+cd "${start_dir}" || exit 1
 
 # Write the results.json file based on the exit code of the command that was 
 # just executed that tested the implementation file
@@ -50,7 +51,7 @@ else
     sanitized_test_output=$(printf '%s' "${test_output}" | sed -n -e '/error: the following test command failed/q;p')
 
     # Try to distinguish between failing tests and errors
-    if [[ ${sanitized_test_output} =~ "error:" ]]; then
+    if echo "${sanitized_test_output}" | grep "error:"; then
         status="error"
     else
         status="fail"


### PR DESCRIPTION
Make the shebang in `run.sh` match that of the other scripts in this repo, and the scripts in [`exercism/generic-test-runner`][1].

This allows removing bash from the image, which does slightly reduce the image size. But the main benefit is probably to clarify to a reader of the `Dockerfile` that the runner doesn't do something complicated with bash-only features.

[1]: https://github.com/exercism/generic-test-runner

Closes: https://github.com/exercism/zig-test-runner/issues/65
Refs: #34 (to a very minor extent)
Refs: #53