### PR TITLE
Dockerfile: create zig cache via `run.sh`, not `zig test`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,6 @@ COPY --chown=ziggy:ziggroup bin/run.sh bin/run.sh
 # Initialize a zig cache
 COPY --chown=ziggy:ziggroup tests/example-success/example_success.zig init-zig-cache/
 COPY --chown=ziggy:ziggroup tests/example-success/test_example_success.zig init-zig-cache/
-RUN zig test init-zig-cache/test_example_success.zig \
+RUN bin/run.sh example-success init-zig-cache init-zig-cache \
     && rm -rf init-zig-cache/
 ENTRYPOINT ["/opt/test-runner/bin/run.sh"]


### PR DESCRIPTION
Three recent commits (82b56afe8200, b8b9d0221601, 3f2c0c29aefb) tried to speed up running user solutions in production, but weren't sufficient. Continue trying, by running `zig test` indirectly.

Extra advantage: we have a single source of truth for `zig test` options if we change them later (like in follow-up PR https://github.com/exercism/zig-test-runner/pull/71, if this one is not sufficient).

Disadvantage: `docker build` no longer fails if this line produces a failing test. That's why I didn't do it this way originally.

Refs: #63