### PR TITLE
bin(run): specify `-target` for `zig test`

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -37,7 +37,7 @@ cd "${solution_dir}" || exit 1
 
 # Run the tests for the provided implementation file and redirect stdout and
 # stderr to capture it
-test_output=$(zig test "${test_file}" 2>&1)
+test_output=$(zig test -target x86_64-linux-musl "${test_file}" 2>&1)
 exit_code=$?
 
 cd "${start_dir}" || exit 1


### PR DESCRIPTION
To-do:

- [x] Merge https://github.com/exercism/zig-test-runner/pull/70
- [x] Rebase this PR on top
- [x] Check whether the above PR produced a speed up in production
- [x] If not, merge this PR

---

Four recent commits (82b56afe8200, b8b9d0221601, 3f2c0c29aefb, 063642036853) tried to speed up running user solutions in production, but weren't sufficient. Continue trying.

With Exercism's test runner architecture, the x86_64 CPU that creates the cache is likely to have different features than the x86_64 CPU that runs `zig test` in production. If that meant that Zig couldn't use the cache, this commit might help.

Refs: #63

---

The `~/.cache/zig/o/` directory contains subdirectories with a `builtin.zig` file.

Before this PR, running:

```shell
docker run \
  --rm \
  --entrypoint /bin/sh \
  exercism/zig-test-runner \
  -c 'cat /home/ziggy/.cache/zig/o/*/builtin.zig'
```

produces output that includes this `builtin.zig`:

<details>
<summary>Click to expand</summary>

```zig
const std = @import("std");
/// Zig version. When writing code that supports multiple versions of Zig, prefer
/// feature detection (i.e. with `@hasDecl` or `@hasField`) over version checks.
pub const zig_version = std.SemanticVersion.parse(zig_version_string) catch unreachable;
pub const zig_version_string = "0.11.0";
pub const zig_backend = std.builtin.CompilerBackend.stage2_llvm;

pub const output_mode = std.builtin.OutputMode.Exe;
pub const link_mode = std.builtin.LinkMode.Static;
pub const is_test = true;
pub const single_threaded = false;
pub const abi = std.Target.Abi.musl;
pub const cpu: std.Target.Cpu = .{
    .arch = .x86_64,
    .model = &std.Target.x86.cpu.icelake_server,
    .features = std.Target.x86.featureSet(&[_]std.Target.x86.Feature{
        .@"64bit",
        .adx,
        .aes,
        .allow_light_256_bit,
        .avx,
        .avx2,
        .avx512bw,
        .avx512cd,
        .avx512dq,
        .avx512f,
        .avx512vl,
        .bmi,
        .bmi2,
        .clflushopt,
        .cmov,
        .crc32,
        .cx16,
        .cx8,
        .ermsb,
        .f16c,
        .fast_15bytenop,
        .fast_gather,
        .fast_scalar_fsqrt,
        .fast_shld_rotate,
        .fast_variable_crosslane_shuffle,
        .fast_variable_perlane_shuffle,
        .fast_vector_fsqrt,
        .fma,
        .fsgsbase,
        .fsrm,
        .fxsr,
        .idivq_to_divl,
        .invpcid,
        .lzcnt,
        .macrofusion,
        .mmx,
        .movbe,
        .nopl,
        .pclmul,
        .popcnt,
        .prefer_256_bit,
        .prfchw,
        .rdrnd,
        .rdseed,
        .rtm,
        .sahf,
        .sse,
        .sse2,
        .sse3,
        .sse4_1,
        .sse4_2,
        .ssse3,
        .vzeroupper,
        .x87,
        .xsave,
        .xsavec,
        .xsaveopt,
        .xsaves,
    }),
};
pub const os = std.Target.Os{
    .tag = .linux,
    .version_range = .{ .linux = .{
        .range = .{
            .min = .{
                .major = 5,
                .minor = 15,
                .patch = 0,
            },
            .max = .{
                .major = 5,
                .minor = 15,
                .patch = 0,
            },
        },
        .glibc = .{
            .major = 2,
            .minor = 19,
            .patch = 0,
        },
    }},
};
pub const target = std.Target{
    .cpu = cpu,
    .os = os,
    .abi = abi,
    .ofmt = object_format,
};
pub const object_format = std.Target.ObjectFormat.elf;
pub const mode = std.builtin.Mode.Debug;
pub const link_libc = false;
pub const link_libcpp = false;
pub const have_error_return_tracing = true;
pub const valgrind_support = true;
pub const sanitize_thread = false;
pub const position_independent_code = false;
pub const position_independent_executable = false;
pub const strip_debug_info = false;
pub const code_model = std.builtin.CodeModel.default;
pub const omit_frame_pointer = false;
pub var test_functions: []const std.builtin.TestFn = undefined; // overwritten later
pub const test_io_mode = .blocking;
```

</details>

With this PR, the diff to that file is below. Note the smaller subset of x86_64 CPU features. But I don't know why it specifies 5.10.81 (2021-11-21) as the maximum Linux version. Especially given that Alpine 3.18 is using Linux 6.1.

```diff
@@ -12,66 +12,22 @@ pub const single_threaded = false;
 pub const abi = std.Target.Abi.musl;
 pub const cpu: std.Target.Cpu = .{
     .arch = .x86_64,
-    .model = &std.Target.x86.cpu.icelake_server,
+    .model = &std.Target.x86.cpu.x86_64,
     .features = std.Target.x86.featureSet(&[_]std.Target.x86.Feature{
         .@"64bit",
-        .adx,
-        .aes,
-        .allow_light_256_bit,
-        .avx,
-        .avx2,
-        .avx512bw,
-        .avx512cd,
-        .avx512dq,
-        .avx512f,
-        .avx512vl,
-        .bmi,
-        .bmi2,
-        .clflushopt,
         .cmov,
-        .crc32,
-        .cx16,
         .cx8,
-        .ermsb,
-        .f16c,
-        .fast_15bytenop,
-        .fast_gather,
-        .fast_scalar_fsqrt,
-        .fast_shld_rotate,
-        .fast_variable_crosslane_shuffle,
-        .fast_variable_perlane_shuffle,
-        .fast_vector_fsqrt,
-        .fma,
-        .fsgsbase,
-        .fsrm,
         .fxsr,
         .idivq_to_divl,
-        .invpcid,
-        .lzcnt,
         .macrofusion,
         .mmx,
-        .movbe,
         .nopl,
-        .pclmul,
-        .popcnt,
-        .prefer_256_bit,
-        .prfchw,
-        .rdrnd,
-        .rdseed,
-        .rtm,
-        .sahf,
+        .slow_3ops_lea,
+        .slow_incdec,
         .sse,
         .sse2,
-        .sse3,
-        .sse4_1,
-        .sse4_2,
-        .ssse3,
         .vzeroupper,
         .x87,
-        .xsave,
-        .xsavec,
-        .xsaveopt,
-        .xsaves,
     }),
 };
 pub const os = std.Target.Os{
@@ -79,14 +35,14 @@ pub const os = std.Target.Os{
     .version_range = .{ .linux = .{
         .range = .{
             .min = .{
-                .major = 5,
-                .minor = 15,
+                .major = 3,
+                .minor = 16,
                 .patch = 0,
             },
             .max = .{
                 .major = 5,
-                .minor = 15,
-                .patch = 0,
+                .minor = 10,
+                .patch = 81,
             },
         },
         .glibc = .{
```