### PR TITLE
.github(lint_dockerfile): add dockle job

### DIFF
--- a/.github/workflows/lint_dockerfile.yml
+++ b/.github/workflows/lint_dockerfile.yml
@@ -13,3 +13,23 @@ jobs:
         uses: hadolint/hadolint-action@54c9adbab1582c2ef04b2016b760714a4bfde3cf
         with:
           dockerfile: Dockerfile
+
+  dockle:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
+
+      - name: Build an image from the Dockerfile
+        run: |
+          docker build -t built-image:scan .
+
+      - name: Run dockle
+        uses: goodwithtech/dockle-action@11c82d478fec09ed1aa56d933eab25218e22bb90
+        with:
+          image: 'built-image:scan'
+          format: 'list'
+          exit-code: '1'
+          exit-level: 'warn'
+          accept-key: 'PATH'


### PR DESCRIPTION
Our CI already lints our Dockerfile with [hadolint][1]. Add checking with [dockle][2] too.

dockle seems to have extra security-auditing functionality. For example, the hadolint workflow succeeded back when the Dockerfile didn't set `USER`. 

For more details, see dockle's [comparison table][3] of Dockerfile checking tools. For the features listed in that table, dockle claims to do everything that hadolint does. But I believe hadolint does do things that dockle doesn't. So let's not remove hadolint, and just use both for now.

In the future, we could add a vulnerability scanner too.

The latest release of the action uses dockle 0.4.10. Pin to the latest commit of the action, which uses dockle 0.4.13.

The current output is:

```text
INFO	- CIS-DI-0005: Enable Content trust for Docker
	* export DOCKER_CONTENT_TRUST=1 before docker pull/build
INFO	- CIS-DI-0006: Add HEALTHCHECK instruction to the container image
	* not found HEALTHCHECK statement
```

Later, we can consider:

- resolving those items
- setting the `exit-level` to `'info'`

This PR sets `accept-key: 'PATH'` to avoid the output:

```text
FATAL	- CIS-DI-0010: Do not store credential in environment variables/files
	* Suspicious ENV key found : PATH on ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/zig (You can suppress it with --accept-key)
```

[1]: https://github.com/hadolint/hadolint
[2]: https://github.com/goodwithtech/dockle
[3]: https://github.com/goodwithtech/dockle/blob/99677e8f23e2/README.md#checkpoints-comparison