### PR TITLE
.github: add actionlint workflow

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -12,6 +12,9 @@ jobs:
       - name: Download actionlint
         id: get_actionlint
         run: |
+          # There is not yet an official action for actionlint.
+          # Adapt the suggested usage:
+          # https://github.com/rhysd/actionlint/blob/f1d409537e61/docs/usage.md#use-actionlint-on-github-actions
           script_name='download-actionlint.bash'
           version='f1d409537e61a3df9206bcdf8c2548e34cb9b16d'
           url="https://raw.githubusercontent.com/rhysd/actionlint/${version}/scripts/${script_name}"


### PR DESCRIPTION
Make CI lint GitHub Actions workflows with [actionlint][1]. See the [list of actionlint checks][2].

There isn't an official actionlint action, so I adapted the [suggested usage](https://github.com/rhysd/actionlint/blob/f1d409537e61a3df9206bcdf8c2548e34cb9b16d/docs/usage.md#use-actionlint-on-github-actions).

[1]: https://github.com/rhysd/actionlint
[2]: https://github.com/rhysd/actionlint/blob/f1d409537e61/docs/checks.md

---

To-do:

- [ ] Consider using one of these:
   - https://github.com/reviewdog/action-actionlint
   - https://github.com/raven-actions/actionlint
   - https://github.com/devops-actions/actionlint
   - https://github.com/eifinger/actionlint-action 